### PR TITLE
remove snapshots from robolectric dependencies

### DIFF
--- a/ota/build.gradle
+++ b/ota/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile 'com.squareup.retrofit2:converter-gson:2.0.2'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.1-SNAPSHOT'
-    testCompile 'org.robolectric:shadows-support-v4:3.1-SNAPSHOT'
+    testCompile 'org.robolectric:robolectric:3.1'
+    testCompile 'org.robolectric:shadows-support-v4:3.1'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
 }


### PR DESCRIPTION
Can the maven snapshot url (lines 5-7) also be removed?
